### PR TITLE
[HM-399] Guard endpoints with `secret_token`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules
 dist
 test

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nestgram",
   "description": "Framework for working with Telegram Bot API on TypeScript like Nest.js",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Degreet <degreetpro@gmail.com>",


### PR DESCRIPTION
This change implements a guard in the Webhook handler which ensures that the `X-Telegram-Bot-Api-Secret-Token` header is set with the `secret_token` value provided to Telegram when the webhook was set up.

This adds a stronger level of security to a NestGram app, as it requires that any request knows this secret value, which only Telegram should have access to during Webhook setup.