### PR TITLE
[HM-401] Close bad requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nestgram",
   "description": "Framework for working with Telegram Bot API on TypeScript like Nest.js",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Degreet <degreetpro@gmail.com>",


### PR DESCRIPTION
This change modifies the NestGram handler `catch` block to close requests. This properly closes any open HTTP requests that end up returning an error.