### PR TITLE
[HM-417] Avoid creating file logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nestgram",
   "description": "Framework for working with Telegram Bot API on TypeScript like Nest.js",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Degreet <degreetpro@gmail.com>",

--- a/src/classes/Helpers/FileLogger.ts
+++ b/src/classes/Helpers/FileLogger.ts
@@ -7,6 +7,8 @@ export class FileLogger {
   logsFilePath: string = path.resolve(this.nestgramInfoDirPath, 'logs.md');
 
   constructor(private readonly limit: number) {
+    if (process.env.DISABLE_LOGS) return;
+
     this.setupLogsFile();
   }
 
@@ -25,6 +27,8 @@ export class FileLogger {
   }
 
   async saveLog(update: IUpdate): Promise<void> {
+    if (process.env.DISABLE_LOGS) return;
+
     const date: string = new Date().toISOString();
     const oldLogsFileText: string = (await fs.readFile(this.logsFilePath)).toString();
     const updateText = JSON.stringify(update, null, 2);

--- a/src/classes/Media/MediaCache.ts
+++ b/src/classes/Media/MediaCache.ts
@@ -9,6 +9,8 @@ export class MediaCache {
   file: editJsonFile.JsonEditor;
 
   constructor() {
+    if (process.env.DISABLE_LOGS) return;
+
     this.getJSONFile();
   }
 
@@ -29,10 +31,14 @@ export class MediaCache {
   }
 
   saveMediaFileId(path: string, fileId: string): void {
+    if (process.env.DISABLE_LOGS) return;
+
     this.file.set(path, fileId);
   }
 
   getMediaFileId(path: string): string | undefined {
+    if (process.env.DISABLE_LOGS) return undefined;
+
     // @ts-ignore
     return this.file.data[path];
   }


### PR DESCRIPTION
This change makes NestGram stop from creating file logs when the `DISABLE_LOGS` environment variable is set.