### PR TITLE
Catch out-of-band handler errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nestgram",
   "description": "Framework for working with Telegram Bot API on TypeScript like Nest.js",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Degreet <degreetpro@gmail.com>",

--- a/src/classes/Api.ts
+++ b/src/classes/Api.ts
@@ -159,7 +159,7 @@ export class Api {
 
       return data.result;
     } catch (e: any) {
-      throw error(`.callApi error: ${e.response?.data?.description || e}`);
+      throw error(`.callApi error (method: ${method}): ${e.response?.data?.description || e}`);
     }
   }
 

--- a/src/classes/Launch/Handler.ts
+++ b/src/classes/Launch/Handler.ts
@@ -315,9 +315,17 @@ export class Handler {
             actionToDo();
           }
         } else {
-          const [sendMethodKey, answerCallArgs]: [string, any[]] =
-            Handler.getAnswerInfo(actionToDo);
-          await answer[sendMethodKey](...answerCallArgs);
+          try {
+            const [sendMethodKey, answerCallArgs]: [string, any[]] =
+              Handler.getAnswerInfo(actionToDo);
+            await answer[sendMethodKey](...answerCallArgs);
+          } catch (e: unknown) {
+            if (e instanceof Error) {
+              console.error(e.stack ?? e.message);
+            } else {
+              console.error(JSON.stringify(e));
+            }
+          }
         }
       }
     };


### PR DESCRIPTION
This change makes sure that, when returning an action from a handler
(e.g. `Delete`, `MessageSend`), that if this action fails, the promise
rejection is caught.

Previously this would not be caught, and the server would halt.