### PR TITLE
[HM-588] Only register webhook when necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nestgram",
   "description": "Framework for working with Telegram Bot API on TypeScript like Nest.js",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Degreet <degreetpro@gmail.com>",

--- a/src/nest-gram.ts
+++ b/src/nest-gram.ts
@@ -19,6 +19,7 @@ import { Polling } from './classes/Launch/Polling';
 import { Webhook } from './classes/Launch/Webhook';
 import { ScopeController } from './classes/Scope/ScopeController';
 import { scopeStore } from './classes/Scope/ScopeStore';
+import { Handler } from './classes/Launch/Handler';
 
 // clear console
 clear();
@@ -199,13 +200,19 @@ export class NestGram {
 
       // start server and save webhook
       this.webhook = new Webhook(
-        this.token,
-        this.handlers,
+        new Api(this.token),
         this.config,
-        this.runConfig.logging,
-        this.runConfig.fileLogging,
-        this.runConfig.fileLoggingLimit,
+        this.runConfig,
+        new Handler(
+          this.token,
+          this.handlers,
+          this.runConfig.logging,
+          this.runConfig.fileLogging,
+          this.runConfig.fileLoggingLimit,
+        ),
       );
+
+      await this.webhook.start();
     }
 
     // log that bot started

--- a/src/util/Undefined.ts
+++ b/src/util/Undefined.ts
@@ -1,0 +1,10 @@
+/**
+ * Narrows `T` to a value which is not `null` or `undefined`,
+ * or throws an error if it is `null` or `undefined`.
+ */
+export function throwIfNullish<T>(t: T | null | undefined): T {
+  if (t === null || t === undefined) {
+    throw new Error('Expected non-nullish value!');
+  }
+  return t;
+}


### PR DESCRIPTION
This change modifies NestGram to ask Telegram if a webhook is currently registered for the bot. If the bot is already registered, the webhook does not try to re-register itself.

This prevents a thundering-herd problem caused by many instances bot starting up at once, all attempting to register the webhook, though not completely -- in this situation, it's likely that many bots will still fail to register an endpoint due to rate-limiting, but once they start back up they won't need to re-register.